### PR TITLE
Fix menu display logic

### DIFF
--- a/src/context-menu-item.js
+++ b/src/context-menu-item.js
@@ -11,7 +11,7 @@ class ContextMenuItem extends MenuItem {
 
     // Close the containing menu after the call stack clears.
     window.setTimeout(() => {
-      this.player().contextmenuUI.closeMenu();
+      this.player().contextmenuUI.menu.dispose();
     }, 1);
   }
 }

--- a/src/context-menu.js
+++ b/src/context-menu.js
@@ -1,0 +1,43 @@
+import window from 'global/window';
+import videojs from 'video.js';
+import ContextMenuItem from './context-menu-item';
+
+const Menu = videojs.getComponent('Menu');
+
+class ContextMenu extends Menu {
+
+  constructor(player, options) {
+    super(player, options);
+
+    // Each menu component has its own `dispose` method that can be
+    // safely bound and unbound to events while maintaining its context.
+    this.dispose = videojs.bind(this, this.dispose);
+
+    options.content.forEach(c => {
+      let fn = function() {};
+
+      if (typeof c.listener === 'function') {
+        fn = c.listener;
+      } else if (typeof c.href === 'string') {
+        fn = () => window.open(c.href);
+      }
+
+      this.addItem(new ContextMenuItem(player, {
+        label: c.label,
+        listener: videojs.bind(player, fn)
+      }));
+    });
+  }
+
+  createEl() {
+    const el = super.createEl();
+
+    videojs.addClass(el, 'vjs-contextmenu-ui-menu');
+    el.style.left = this.options_.position.left + 'px';
+    el.style.top = this.options_.position.top + 'px';
+
+    return el;
+  }
+}
+
+export default ContextMenu;

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -69,6 +69,13 @@ function onVjsContextMenu(e) {
     position: menuPosition
   });
 
+  // This is for backward compatibility. We no longer have the `closeMenu`
+  // function, but removing it would necessitate a major version bump.
+  this.contextmenuUI.closeMenu = () => {
+    videojs.warn('player.contextmenuUI.closeMenu() is deprecated, please use player.contextmenuUI.menu.dispose() instead!');
+    menu.dispose();
+  };
+
   menu.on('dispose', () => {
 
     videojs.log('contextmenu-ui: disposed menu');

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,15 +1,7 @@
 import document from 'global/document';
-import window from 'global/window';
 import videojs from 'video.js';
 import ContextMenu from './context-menu';
-import {getPointerPosition, isDescendantOf} from './util';
-
-const closeEvents = {
-  mousedown: 'mouseup',
-  touchstart: 'touchend'
-};
-
-const closeEventTypes = Object.keys(closeEvents);
+import {getPointerPosition} from './util';
 
 /**
  * Whether or not the player has an active context menu.
@@ -21,17 +13,6 @@ function hasMenu(player) {
   return player.hasOwnProperty('contextmenuUI') &&
     player.contextmenuUI.hasOwnProperty('menu') &&
     player.contextmenuUI.menu.el();
-}
-
-/**
- * Disposes the menu from a player if it hasn't already been disposed.
- *
- * @param  {Player} player
- */
-function maybeDisposeMenu(player) {
-  if (hasMenu(player)) {
-    player.contextmenuUI.menu.dispose();
-  }
 }
 
 /**

--- a/src/util.js
+++ b/src/util.js
@@ -57,13 +57,12 @@ export function findElPosition(el) {
  *         mouse position
  */
 export function getPointerPosition(el, event) {
-  let position = {};
-  let box = findElPosition(el);
-  let boxW = el.offsetWidth;
-  let boxH = el.offsetHeight;
-
-  let boxY = box.top;
-  let boxX = box.left;
+  const position = {};
+  const box = findElPosition(el);
+  const boxW = el.offsetWidth;
+  const boxH = el.offsetHeight;
+  const boxY = box.top;
+  const boxX = box.left;
   let pageY = event.pageY;
   let pageX = event.pageX;
 
@@ -76,24 +75,4 @@ export function getPointerPosition(el, event) {
   position.x = Math.max(0, Math.min(1, (pageX - boxX) / boxW));
 
   return position;
-}
-
-/**
- * Whether a given el is a descendant of parent el.
- *
- * @param  {Element} el
- * @param  {Element} parent
- * @return {Boolean}
- */
-export function isDescendantOf(el, parent) {
-  let temp = el;
-
-  while (temp.parentNode) {
-    if (temp.parentNode === parent) {
-      return true;
-    }
-    temp = temp.parentNode;
-  }
-
-  return false;
 }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -65,21 +65,7 @@ QUnit.test(tsmlj`
 });
 
 QUnit.test(tsmlj`
-  closes the custom context menu when interacting with the player
-`, function(assert) {
-  this.player.trigger({
-    type: 'vjs-contextmenu',
-    pageX: 0,
-    pageY: 0
-  });
-
-  this.player.tech_.trigger('mousedown');
-
-  assert.strictEqual(this.player.$$('.vjs-contextmenu-ui-menu').length, 0);
-});
-
-QUnit.test(tsmlj`
-  does not open a custom context menu on the second "vjs-contextmenu" event
+  closes the custom context menu on the second "vjs-contextmenu" event
   encountered
 `, function(assert) {
   this.player.trigger({
@@ -88,13 +74,26 @@ QUnit.test(tsmlj`
     pageY: 0
   });
 
-  this.player.tech_.trigger('mousedown');
-
   this.player.trigger({
     type: 'vjs-contextmenu',
     pageX: 0,
     pageY: 0
   });
+
+  assert.strictEqual(this.player.$$('.vjs-contextmenu-ui-menu').length, 0);
+});
+
+QUnit.test(tsmlj`
+  closes the custom context menu when interacting with the player or document
+  outside the menu
+`, function(assert) {
+  this.player.trigger({
+    type: 'vjs-contextmenu',
+    pageX: 0,
+    pageY: 0
+  });
+
+  videojs.trigger(document, 'click');
 
   assert.strictEqual(this.player.$$('.vjs-contextmenu-ui-menu').length, 0);
 });


### PR DESCRIPTION
The intent was for the menu to open in the same fashion as YouTube:

- The first vjs-contextmenu event opens the custom menu.
- Subsequent vjs-contextmenu events (while the custom menu is open) will
  close the custom menu and allow the native menu to appear.
  - The latter behavior is manipulated by setting the `cancel` option
    for the `contextmenu` plugin.

Also, moved a lot of logic into a new `ContextMenu` component in an attempt to keep things more sane and did some general refactoring.