### PR TITLE
Disable native context menu

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -44,6 +44,7 @@ function onContextMenu(e) {
   // open the custom menu.
   if (hasMenu(this)) {
     this.contextmenuUI.menu.dispose();
+    e.preventDefault();
     return;
   }
 


### PR DESCRIPTION
## Description
When the custom menu is open and a contextmenu event happens, the native context menu will open. This commit prevents the native context menu from opening.

## Specific Changes proposed
Added `event.preventDefault()` on contextmenu event if the custom menu is open.

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
