### PR TITLE
Fix: a workaround for a Firefox issue where 'oncontextmenu' event triggers 'click' event

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -91,7 +91,11 @@ function onContextMenu(e) {
     )) + 'px';
   }
 
-  videojs.on(document, ['click', 'tap'], menu.dispose);
+  // A workaround for Firefox issue  where "oncontextmenu" event
+  // leaks "click" event to document https://bugzilla.mozilla.org/show_bug.cgi?id=990614
+  const documentEl = videojs.browser.IS_FIREFOX ? document.documentElement : document;
+
+  videojs.on(documentEl, ['click', 'tap'], menu.dispose);
 }
 
 /**
@@ -101,7 +105,7 @@ function onContextMenu(e) {
  * @param    {Object} options
  * @param    {Array}  options.content
  *           An array of objects which populate a content list within the menu.
- * @param    {Boolean}  options.keepInside
+ * @param    {boolean}  options.keepInside
  *           Whether to always keep the menu inside the player
  */
 function contextmenuUI(options) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -52,6 +52,9 @@ function onContextMenu(e) {
   const pointerPosition = getPointerPosition(this.el(), e);
   const playerSize = this.el().getBoundingClientRect();
   const menuPosition = findMenuPosition(pointerPosition, playerSize);
+  // A workaround for Firefox issue  where "oncontextmenu" event
+  // leaks "click" event to document https://bugzilla.mozilla.org/show_bug.cgi?id=990614
+  const documentEl = videojs.browser.IS_FIREFOX ? document.documentElement : document;
 
   e.preventDefault();
 
@@ -68,7 +71,7 @@ function onContextMenu(e) {
   };
 
   menu.on('dispose', () => {
-    videojs.off(document, ['click', 'tap'], menu.dispose);
+    videojs.off(documentEl, ['click', 'tap'], menu.dispose);
     this.removeChild(menu);
     delete this.contextmenuUI.menu;
   });
@@ -90,10 +93,6 @@ function onContextMenu(e) {
       this.player_.currentHeight() - menu.currentHeight()
     )) + 'px';
   }
-
-  // A workaround for Firefox issue  where "oncontextmenu" event
-  // leaks "click" event to document https://bugzilla.mozilla.org/show_bug.cgi?id=990614
-  const documentEl = videojs.browser.IS_FIREFOX ? document.documentElement : document;
 
   videojs.on(documentEl, ['click', 'tap'], menu.dispose);
 }

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -86,7 +86,11 @@ QUnit.test('closes the custom context menu when interacting with the player or d
     pageY: 0
   });
 
-  videojs.trigger(document, 'click');
+  // A workaround for Firefox issue  where "oncontextmenu" event
+  // leaks "click" event to document  https://bugzilla.mozilla.org/show_bug.cgi?id=990614
+  const documentEl = videojs.browser.IS_FIREFOX ? document.documentElement : document;
+
+  videojs.trigger(documentEl, 'click');
 
   assert.strictEqual(this.player.$$('.vjs-contextmenu-ui-menu').length, 0);
 });


### PR DESCRIPTION
## Description
Proposed solution for [BC-45111](https://jira.brightcove.com/browse/BC-45111)

## Specific Changes proposed
Add `click` listener on `document.documentElement` instead of `document` in Firefox to workaround the issue where `click` event is leaked on document's `oncontextmenu` event.

## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
