### PR TITLE
feat: prevent contextmenu from appearing in input elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Maintenance Status: Stable
 - [Usage](#usage)
 - [Options](#options)
   - [`content`](#content)
+  - [`keepInside`](#keepinside)
+  - [`preventInputElementsMenu`](#preventinputelementsmenu)
 - [Inclusion](#inclusion)
   - [`<script>` Tag](#script-tag)
   - [CommonJS/Browserify](#commonjsbrowserify)
@@ -65,7 +67,8 @@ player.contextmenuUI({
     listener: function() {
       alert('you clicked the example link!');
     }
-  }]
+  }],
+  preventInputElementsMenu: true
 });
 ```
 
@@ -85,6 +88,12 @@ The plugin requires that `content` be passed as an array. If it is not, an error
 **Type**: Boolean
 
 If `true` (default), the context menu will be kept within the bounds of the player. If `false`, it may extend outside. When set to `false`, the menu would still stay within the player if the menu would otherwise extend outside the document body, including fullscreen players and players in an iframe.
+
+### `preventInputElementsMenu`
+
+**Type**: Boolean
+
+If `false` (default), the context menu will appear when the user is in an input element. If `true`, the context menu will not appear when the user is in an input element.
 
 ## Inclusion
 

--- a/index.html
+++ b/index.html
@@ -31,7 +31,8 @@
           listener: function() {
             alert('you clicked the example link!');
           }
-        }]
+        }],
+        preventInputElementsMenu: true
       });
     }(window, window.videojs));
   </script>

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -47,6 +47,13 @@ function onContextMenu(e) {
     return;
   }
 
+  // Prevent context menu from appearing when the user is in an input element
+  if (this.contextmenuUI.preventInputElementsMenu) {
+    if (e.target.tagName === 'INPUT') {
+      return;
+    }
+  }
+
   // Calculate the positioning of the menu based on the player size and
   // triggering event.
   const pointerPosition = getPointerPosition(this.el(), e);
@@ -106,10 +113,13 @@ function onContextMenu(e) {
  *           An array of objects which populate a content list within the menu.
  * @param    {boolean}  options.keepInside
  *           Whether to always keep the menu inside the player
+ * @param    {boolean}  options.preventInputElementsMenu
+ *           Whether to prevent the context menu from appearing in input elements
  */
 function contextmenuUI(options) {
   const defaults = {
-    keepInside: true
+    keepInside: true,
+    preventInputElementsMenu: false
   };
 
   options = videojs.mergeOptions(defaults, options);
@@ -138,6 +148,7 @@ function contextmenuUI(options) {
   cmui.onContextMenu = videojs.bind(this, onContextMenu);
   cmui.content = options.content;
   cmui.keepInside = options.keepInside;
+  cmui.preventInputElementsMenu = options.preventInputElementsMenu;
   cmui.VERSION = VERSION;
 
   this.on('contextmenu', cmui.onContextMenu);

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -37,7 +37,8 @@ QUnit.module('videojs-contextmenu-ui', {
         listener() {
           videojs.log('you clicked the example link!');
         }
-      }]
+      }],
+      preventInputElementsMenu: true
     });
 
     // Tick the clock forward enough to trigger the player to be "ready".
@@ -91,6 +92,21 @@ QUnit.test('closes the custom context menu when interacting with the player or d
   const documentEl = videojs.browser.IS_FIREFOX ? document.documentElement : document;
 
   videojs.trigger(documentEl, 'click');
+
+  assert.strictEqual(this.player.$$('.vjs-contextmenu-ui-menu').length, 0);
+});
+
+QUnit.test('do not open context menu if in input element', function(assert) {
+  const inputElement = document.createElement('input');
+
+  inputElement.className = 'vjs-input-element';
+  this.player.createModal(inputElement);
+
+  const rightClick = document.createEvent('MouseEvents');
+
+  rightClick.initMouseEvent('contextmenu', true, true, this.window, 1, 0, 0, 0, 0, false, false, false, false, 2, null);
+
+  this.player.$('.vjs-input-element').dispatchEvent(rightClick);
 
   assert.strictEqual(this.player.$$('.vjs-contextmenu-ui-menu').length, 0);
 });


### PR DESCRIPTION
## Description
The contextmenu prevents users from accessing the native contextmenu in situations where you'd expect to be able to access commands like copy, cut and paste. This is particularly useful if you've created a component like a lead form, social share modal etc.

## Specific Changes proposed
This PR implements an new opt-in that allows you to prevent the contextmenu from appearing in input elements. This allows users to access commands like copy, cut and paste.

![contextmenu](https://user-images.githubusercontent.com/7316615/62785595-f6306580-ba8e-11e9-8b2a-4aee68c1e8a5.gif)

## Requirements Checklist
- [x] Feature implemented / Bug fixed
- [x] If necessary, more likely in a feature request than a bug fix
  - [x] Unit Tests updated or fixed
  - [x] Docs/guides updated
- [ ] Reviewed by Two Core Contributors