### PR TITLE
add support for content as a function

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -1,7 +1,7 @@
 import document from 'global/document';
 import videojs from 'video.js';
 import ContextMenu from './context-menu';
-import {getPointerPosition} from './util';
+import {getPointerPosition, isFunction} from './util';
 import {version as VERSION} from '../package.json';
 
 /**
@@ -75,7 +75,7 @@ function onContextMenu(e) {
   e.preventDefault();
 
   const menu = this.contextmenuUI.menu = new ContextMenu(this, {
-    content: this.contextmenuUI.content,
+    content: isFunction(this.contextmenuUI.content) && this.contextmenuUI.content() || this.contextmenuUI.content,
     position: menuPosition
   });
 
@@ -133,7 +133,7 @@ function contextmenuUI(options) {
 
   options = videojs.mergeOptions(defaults, options);
 
-  if (!Array.isArray(options.content)) {
+  if (!Array.isArray(options.content) && !Array.isArray(options.content())) {
     throw new Error('"content" required');
   }
 

--- a/src/util.js
+++ b/src/util.js
@@ -76,3 +76,7 @@ export function getPointerPosition(el, event) {
 
   return position;
 }
+
+export function isFunction(functionToCheck) {
+  return functionToCheck && {}.toString.call(functionToCheck) === '[object Function]';
+}


### PR DESCRIPTION
## Description
## Specific Changes proposed
This PR adds support for content as a function. This allows the menu to be re-evaluated on each `oncontextmenu` event.

<!--
## Requirements Checklist
- [ ] Feature implemented / Bug fixed
- [ ] If necessary, more likely in a feature request than a bug fix
  - [ ] Unit Tests updated or fixed
  - [ ] Docs/guides updated
- [ ] Reviewed by Two Core Contributors
-->